### PR TITLE
is window alive ignores panes

### DIFF
--- a/layers/ii-mate/local/ob-tmate/ob-tmate.el
+++ b/layers/ii-mate/local/ob-tmate/ob-tmate.el
@@ -535,7 +535,7 @@ Argument OB-SESSION: the current ob-tmate session."
 
 If no window is specified in OB-SESSION, returns 't."
   (let* (
-         (window (ob-tmate--window-default ob-session))
+         (window (car(split-string (ob-tmate--window-default ob-session) ".")));only grab window, ignoring pane if given
 	       (target (ob-tmate--target ob-session))
          ;; This appears to hang if we let it run early
 	       (output (ob-tmate--execute-string ob-session


### PR DESCRIPTION
change the window var in `ob-tmate--window-alive-p` so that it's only looking at the tmate and not a possible additional pane.
If someone wanted to pass a window and pane, it's written as `window.pane`
by splitting on the dot, we ensure that `foo` and `foo.right` both return foo, which is what the function is intended to check.